### PR TITLE
use forge default for remaps

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,7 @@
     "solidity.formatter": "prettier",
     "[solidity]": {
         "editor.defaultFormatter": "JuanBlanco.solidity"
-    }
+    },
+    "solidity.packageDefaultDependenciesContractsDirectory": "src",
+    "solidity.packageDefaultDependenciesDirectory": "lib"
 }

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,3 +1,0 @@
-ds-test/=lib/ds-test/src/
-solmate/=lib/solmate/src/
-forge-std/=lib/forge-std/src/


### PR DESCRIPTION
fairly minor change, allows users to run `forge install pkg` and be automatically able to use the package with vscode-solidity and forge immediately. the only necessary entries in `remappings.txt` necessary are for less standard package formats (eg openzeppelin contracts) - so leaving the remappings.txt file there